### PR TITLE
feat(ui): add runtime theme switching with Midnight and Pastel Colors themes

### DIFF
--- a/src-tauri/src/db/commands.rs
+++ b/src-tauri/src/db/commands.rs
@@ -24,6 +24,7 @@ pub struct DbPreferences {
     pub current_playlist: Vec<String>,
     pub on_repeat: bool,
     pub on_shuffle: bool,
+    pub theme: String,
 }
 
 // ── helpers (testable without Tauri State) ────────────────────────────────────
@@ -120,6 +121,7 @@ pub(crate) fn get_preferences(conn: &Connection) -> Result<DbPreferences, String
             .unwrap_or_default(),
         on_repeat: get("on_repeat").map(|v| v == "true").unwrap_or(false),
         on_shuffle: get("on_shuffle").map(|v| v == "true").unwrap_or(false),
+        theme: get("theme").unwrap_or_else(|| "Midnight".to_string()),
     })
 }
 
@@ -129,6 +131,7 @@ pub(crate) fn save_preferences(
     current_playlist: &[String],
     on_repeat: bool,
     on_shuffle: bool,
+    theme: &str,
 ) -> Result<(), String> {
     let upsert = |key: &str, value: &str| {
         conn.execute(
@@ -152,6 +155,7 @@ pub(crate) fn save_preferences(
     upsert("current_playlist", &playlist_json).map_err(|e| e.to_string())?;
     upsert("on_repeat", if on_repeat { "true" } else { "false" }).map_err(|e| e.to_string())?;
     upsert("on_shuffle", if on_shuffle { "true" } else { "false" }).map_err(|e| e.to_string())?;
+    upsert("theme", theme).map_err(|e| e.to_string())?;
 
     Ok(())
 }
@@ -222,6 +226,7 @@ pub fn db_save_preferences(
     current_playlist: Vec<String>,
     on_repeat: bool,
     on_shuffle: bool,
+    theme: String,
 ) -> Result<(), String> {
     let conn = state.conn.lock().map_err(|e| e.to_string())?;
     save_preferences(
@@ -230,6 +235,7 @@ pub fn db_save_preferences(
         &current_playlist,
         on_repeat,
         on_shuffle,
+        &theme,
     )
 }
 
@@ -420,6 +426,7 @@ mod tests {
         assert!(prefs.current_playlist.is_empty());
         assert!(!prefs.on_repeat);
         assert!(!prefs.on_shuffle);
+        assert_eq!(prefs.theme, "Midnight");
     }
 
     #[test]
@@ -428,13 +435,22 @@ mod tests {
         let conn = db.conn.lock().unwrap();
         let playlist = vec!["/a.mp3".to_string(), "/b.mp3".to_string()];
 
-        save_preferences(&conn, Some("/music/song.mp3"), &playlist, true, false).unwrap();
+        save_preferences(
+            &conn,
+            Some("/music/song.mp3"),
+            &playlist,
+            true,
+            false,
+            "Pastel Colors",
+        )
+        .unwrap();
 
         let prefs = get_preferences(&conn).unwrap();
         assert_eq!(prefs.current_path.as_deref(), Some("/music/song.mp3"));
         assert_eq!(prefs.current_playlist, playlist);
         assert!(prefs.on_repeat);
         assert!(!prefs.on_shuffle);
+        assert_eq!(prefs.theme, "Pastel Colors");
     }
 
     #[test]
@@ -442,8 +458,16 @@ mod tests {
         let db = setup();
         let conn = db.conn.lock().unwrap();
 
-        save_preferences(&conn, Some("/music/song.mp3"), &[], false, false).unwrap();
-        save_preferences(&conn, None, &[], false, false).unwrap();
+        save_preferences(
+            &conn,
+            Some("/music/song.mp3"),
+            &[],
+            false,
+            false,
+            "Midnight",
+        )
+        .unwrap();
+        save_preferences(&conn, None, &[], false, false, "Midnight").unwrap();
 
         let prefs = get_preferences(&conn).unwrap();
         assert!(prefs.current_path.is_none());
@@ -454,12 +478,13 @@ mod tests {
         let db = setup();
         let conn = db.conn.lock().unwrap();
 
-        save_preferences(&conn, None, &[], false, false).unwrap();
-        save_preferences(&conn, None, &[], true, true).unwrap();
+        save_preferences(&conn, None, &[], false, false, "Midnight").unwrap();
+        save_preferences(&conn, None, &[], true, true, "Pastel Colors").unwrap();
 
         let prefs = get_preferences(&conn).unwrap();
         assert!(prefs.on_repeat);
         assert!(prefs.on_shuffle);
+        assert_eq!(prefs.theme, "Pastel Colors");
     }
 
     #[test]
@@ -467,7 +492,7 @@ mod tests {
         let db = setup();
         let conn = db.conn.lock().unwrap();
 
-        save_preferences(&conn, None, &[], false, false).unwrap();
+        save_preferences(&conn, None, &[], false, false, "Midnight").unwrap();
 
         let prefs = get_preferences(&conn).unwrap();
         assert!(prefs.current_playlist.is_empty());

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,18 @@
 import { useEffect, useState } from 'react';
+import { createGlobalStyle, ThemeProvider } from 'styled-components';
 import './App.css';
 import Player from './Pages/Player/Player';
 import { AppContext } from './Context/AppContext';
 import { MetadataType, PlaylistType } from './types';
 import { invoke } from '@tauri-apps/api/core';
+import { themes, defaultTheme } from './theme';
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    background-color: ${({ theme }) => theme.background};
+    color: ${({ theme }) => theme.textPrimary};
+  }
+`;
 
 function App() {
   const [currentPath, setCurrentPath] = useState<string | undefined>(undefined);
@@ -18,6 +27,9 @@ function App() {
   const [library, setLibrary] = useState<MetadataType[]>([]);
   const [libraryPaths, setLibraryPaths] = useState<string[]>([]);
   const [isScanning, setIsScanning] = useState<boolean>(false);
+  const [currentTheme, setCurrentTheme] = useState<string>(defaultTheme.name);
+
+  const activeTheme = themes[currentTheme] ?? defaultTheme;
 
   const scanLibrary = async (paths: string[]) => {
     setIsScanning(true);
@@ -40,10 +52,12 @@ function App() {
           current_playlist: string[];
           on_repeat: boolean;
           on_shuffle: boolean;
+          theme: string;
         }>('db_get_preferences');
         if (prefs.current_playlist.length) setCurrentPlaylist(prefs.current_playlist);
         setOnRepeat(prefs.on_repeat);
         setOnShuffle(prefs.on_shuffle);
+        if (themes[prefs.theme]) setCurrentTheme(prefs.theme);
 
         const dbPlaylists =
           await invoke<{ id: string; name: string; songs: { path: string; title?: string; artist?: string }[] }[]>(
@@ -75,8 +89,9 @@ function App() {
       currentPlaylist,
       onRepeat,
       onShuffle,
+      theme: currentTheme,
     }).catch(() => {});
-  }, [currentPath, currentPlaylist, onRepeat, onShuffle]);
+  }, [currentPath, currentPlaylist, onRepeat, onShuffle, currentTheme]);
 
   // Persist playlists whenever they change
   useEffect(() => {
@@ -100,6 +115,7 @@ function App() {
         metadata,
         playlists,
         currentPlaylist,
+        currentTheme,
         onRepeat,
         onShuffle,
         showQueue,
@@ -108,6 +124,7 @@ function App() {
         isScanning,
         setCurrentPath,
         setCurrentPlaylist,
+        setCurrentTheme,
         setLibrary,
         setLibraryPaths,
         scanLibrary,
@@ -121,7 +138,10 @@ function App() {
         setShowQueue,
       }}
     >
-      <Player />
+      <ThemeProvider theme={activeTheme}>
+        <GlobalStyle />
+        <Player />
+      </ThemeProvider>
     </AppContext.Provider>
   );
 }

--- a/src/Components/BackButton/styles.tsx
+++ b/src/Components/BackButton/styles.tsx
@@ -12,10 +12,10 @@ export const Button = styled.button`
   gap: 0.4rem;
   max-height: 3rem;
   max-width: 6rem;
-  background: #9b7ebd;
+  background: ${({ theme }) => theme.primary};
   border: none;
   border-radius: 2rem;
-  color: #fff;
+  color: ${({ theme }) => theme.textOnPrimary};
   font-size: 0.85rem;
   cursor: pointer;
   padding: 0.4rem 0.9rem;
@@ -24,7 +24,7 @@ export const Button = styled.button`
     color 0.15s;
 
   &:hover {
-    background: #e4d4f7;
-    color: #5a3a7a;
+    background: ${({ theme }) => theme.active};
+    color: ${({ theme }) => theme.primaryDeep};
   }
 `;

--- a/src/Components/Controls/styles.tsx
+++ b/src/Components/Controls/styles.tsx
@@ -12,42 +12,42 @@ const Shuffle = styled(FaShuffle)<{ $onShuffle: boolean }>`
   max-width: 60px;
   max-height: 30px;
   cursor: pointer;
-  color: ${(props) => (props.$onShuffle ? '#f49bab' : '#7f55b1')};
+  color: ${(props) => (props.$onShuffle ? props.theme.accent : props.theme.primaryDark)};
 `;
 
 const Next = styled(FaForward)`
   max-width: 60px;
   max-height: 30px;
   cursor: pointer;
-  color: #f49bab;
+  color: ${({ theme }) => theme.accent};
 `;
 
 const Prev = styled(FaBackward)`
   max-width: 60px;
   max-height: 30px;
   cursor: pointer;
-  color: #f49bab;
+  color: ${({ theme }) => theme.accent};
 `;
 
 const Repeat = styled(FaRepeat)<{ $onRepeat: boolean }>`
   max-width: 60px;
   max-height: 30px;
   cursor: pointer;
-  color: ${(props) => (props.$onRepeat ? '#f49bab' : '#7f55b1')};
+  color: ${(props) => (props.$onRepeat ? props.theme.accent : props.theme.primaryDark)};
 `;
 
 const Play = styled(FaPlay)`
   max-width: 60px;
   max-height: 30px;
   cursor: pointer;
-  color: #f49bab;
+  color: ${({ theme }) => theme.accent};
 `;
 
 const Pause = styled(FaPause)`
   max-width: 60px;
   max-height: 30px;
   cursor: pointer;
-  color: #f49bab;
+  color: ${({ theme }) => theme.accent};
 `;
 
 export { Controls, Shuffle, Next, Prev, Repeat, Play, Pause };

--- a/src/Components/Count/styles.tsx
+++ b/src/Components/Count/styles.tsx
@@ -3,8 +3,8 @@ import { styled } from 'styled-components';
 export const Count = styled.span`
   font-size: 0.9rem;
   font-weight: normal;
-  color: #9b7ebd;
-  background: #f0e0f8;
+  color: ${({ theme }) => theme.primary};
+  background: ${({ theme }) => theme.surfaceRaised};
   border-radius: 1rem;
   padding: 1rem 0.6rem;
   max-width: 3rem;

--- a/src/Components/ErrorBoundary/styles.tsx
+++ b/src/Components/ErrorBoundary/styles.tsx
@@ -9,19 +9,19 @@ export const Container = styled.div`
   width: 100vw;
   gap: 1rem;
   padding: 2rem;
-  background: #faf5ff;
+  background: ${({ theme }) => theme.surface};
 `;
 
 export const Title = styled.h1`
   font-size: 1.25rem;
   font-weight: 600;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   margin: 0;
 `;
 
 export const Message = styled.p`
   font-size: 0.9rem;
-  color: #6b4c8a;
+  color: ${({ theme }) => theme.textSecondary};
   margin: 0;
   text-align: center;
   max-width: 400px;
@@ -29,9 +29,9 @@ export const Message = styled.p`
 
 export const Detail = styled.code`
   font-size: 0.8rem;
-  color: #9b7ebd;
-  background: #f3e8ff;
-  border: 1px solid #d4b8f0;
+  color: ${({ theme }) => theme.primary};
+  background: ${({ theme }) => theme.surfaceRaised};
+  border: 1px solid ${({ theme }) => theme.borderLight};
   border-radius: 0.5rem;
   padding: 0.75rem 1rem;
   max-width: 500px;
@@ -41,8 +41,8 @@ export const Detail = styled.code`
 
 export const ReloadButton = styled.button`
   margin-top: 0.5rem;
-  background: #9b7ebd;
-  color: #fff;
+  background: ${({ theme }) => theme.primary};
+  color: ${({ theme }) => theme.textOnPrimary};
   border: none;
   border-radius: 2rem;
   padding: 0.5rem 1.5rem;
@@ -51,6 +51,6 @@ export const ReloadButton = styled.button`
   transition: background 0.15s;
 
   &:hover {
-    background: #7f55b1;
+    background: ${({ theme }) => theme.primaryDark};
   }
 `;

--- a/src/Components/HeroSection/styles.tsx
+++ b/src/Components/HeroSection/styles.tsx
@@ -27,7 +27,7 @@ export const HeroBg = styled.img`
 export const HeroPlaceholder = styled.div`
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, #7f55b1, #f49bab);
+  background: linear-gradient(135deg, ${({ theme }) => theme.primaryDark}, ${({ theme }) => theme.accent});
   display: flex;
   align-items: center;
   justify-content: center;
@@ -65,5 +65,5 @@ export const HeroStats = styled.div`
 `;
 
 export const HeroContent = styled.div`
-  background: #ffe1e0;
+  background: ${({ theme }) => theme.background};
 `;

--- a/src/Components/PageHeader/styles.tsx
+++ b/src/Components/PageHeader/styles.tsx
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 
 export const PageHeader = styled.h2`
-  color: #5a3a7a;
+  color: ${({ theme }) => theme.primaryDeep};
   margin: 0 0 0.75rem;
   display: flex;
   align-items: center;

--- a/src/Components/Playlist/styles.tsx
+++ b/src/Components/Playlist/styles.tsx
@@ -36,15 +36,15 @@ export const PlayNowButton = styled.button`
   font-size: 1rem;
   gap: 0.5rem;
   max-width: 140px;
-  background-color: #9b7ebd;
-  color: white;
+  background-color: ${({ theme }) => theme.primary};
+  color: ${({ theme }) => theme.textOnPrimary};
   border: none;
   border-radius: 0.75rem;
   cursor: pointer;
 
   &:hover {
-    background: #e4d4f7;
-    color: #5a3a7a;
+    background: ${({ theme }) => theme.active};
+    color: ${({ theme }) => theme.primaryDeep};
   }
 `;
 
@@ -68,7 +68,7 @@ export const Play = styled(FaCirclePlay)`
   max-width: 30px;
   max-height: 30px;
   cursor: pointer;
-  color: #f49bab;
+  color: ${({ theme }) => theme.accent};
 `;
 
 export const SongList = styled.div`
@@ -90,14 +90,14 @@ export const SongItem = styled.div<{ $active?: boolean; $missing?: boolean }>`
   cursor: ${(p) => (p.$missing ? 'default' : 'pointer')};
   border-radius: 0.75rem;
   padding: 0.75rem 0.5rem;
-  background: ${(p) => (p.$active ? '#f49bab33' : 'transparent')};
+  background: ${(p) => (p.$active ? p.theme.accentBg : 'transparent')};
   opacity: ${(p) => (p.$missing ? 0.45 : 1)};
   transition:
     background 0.15s,
     opacity 0.15s;
 
   &:hover {
-    background: ${(p) => (p.$active ? '#f49bab55' : p.$missing ? 'transparent' : '#f7cdd4')};
+    background: ${(p) => (p.$active ? p.theme.accentBgHover : p.$missing ? 'transparent' : p.theme.accentHover)};
   }
 `;
 
@@ -129,7 +129,7 @@ export const SongDuration = styled.span`
 
 export const MissingIcon = styled(FaCircleExclamation)`
   flex-shrink: 0;
-  color: #c0392b;
+  color: ${({ theme }) => theme.error};
   width: 1rem;
   height: 1rem;
 `;
@@ -138,7 +138,7 @@ export const RemoveMissingButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  color: #c0392b;
+  color: ${({ theme }) => theme.error};
   display: flex;
   align-items: center;
   padding: 0.2rem;

--- a/src/Components/ProgressBar/styles.tsx
+++ b/src/Components/ProgressBar/styles.tsx
@@ -1,14 +1,14 @@
 import { styled } from 'styled-components';
 
 const ProgressBarInner = styled.div`
-  background-color: #f49bab;
+  background-color: ${({ theme }) => theme.accent};
   width: 0; /* Adjust with JavaScript */
   height: 20px;
   border-radius: 0px 10px 10px 0px;
 `;
 
 const CustomProgressBar = styled.div`
-  background-color: #7f55b1;
+  background-color: ${({ theme }) => theme.primaryDark};
   border-radius: 0px;
   padding: 0px;
   height: 20px;

--- a/src/Components/Sidebar/styles.tsx
+++ b/src/Components/Sidebar/styles.tsx
@@ -2,14 +2,14 @@ import { FaAngleLeft, FaCompactDisc, FaHouse, FaMicrophoneLines, FaMusic, FaPlus
 import { styled } from 'styled-components';
 
 const SidebarContainer = styled.div`
-  background-color: #f7f4fc;
+  background-color: ${({ theme }) => theme.surfaceAlt};
   width: 30%;
   min-width: 200px;
   display: flex;
   flex-direction: column;
   padding: 1.5rem 1rem;
   overflow-y: auto;
-  border-right: 1px solid #e5d8f5;
+  border-right: 1px solid ${({ theme }) => theme.border};
   gap: 0.1rem;
 `;
 
@@ -24,7 +24,7 @@ const AppLogo = styled.div`
 const AppName = styled.span`
   font-size: 1.1rem;
   font-weight: 700;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
 `;
 
 const SectionLabel = styled.span`
@@ -32,7 +32,7 @@ const SectionLabel = styled.span`
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   padding: 0.75rem 0.5rem 0.25rem;
   display: flex;
   align-items: center;
@@ -52,7 +52,7 @@ const PlusButtonContainer = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -65,8 +65,8 @@ const PlusButtonContainer = styled.button`
   max-height: 2rem;
 
   &:hover {
-    color: #7f55b1;
-    background: #e8d8f5;
+    color: ${({ theme }) => theme.primaryDark};
+    background: ${({ theme }) => theme.hoverActive};
   }
 `;
 
@@ -81,21 +81,21 @@ const MenuItem = styled.div<{ $active?: boolean }>`
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  color: ${(p) => (p.$active ? '#7f55b1' : '#3a1f5a')};
+  color: ${(p) => (p.$active ? p.theme.primaryDark : p.theme.textPrimary)};
   cursor: pointer;
   padding: 0.6rem 0.75rem;
   border-radius: 0.65rem;
   font-size: 0.9rem;
   font-weight: ${(p) => (p.$active ? '600' : '400')};
-  background: ${(p) => (p.$active ? '#e8d8f5' : 'transparent')};
+  background: ${(p) => (p.$active ? p.theme.hoverActive : 'transparent')};
   transition:
     background 0.15s,
     color 0.15s;
   max-height: 3rem;
 
   &:hover {
-    background: ${(p) => (p.$active ? '#e8d8f5' : '#ede5f8')};
-    color: #7f55b1;
+    background: ${(p) => (p.$active ? p.theme.hoverActive : p.theme.hover)};
+    color: ${({ theme }) => theme.primaryDark};
   }
 `;
 
@@ -103,13 +103,13 @@ const PlaylistItem = styled.div<{ $active?: boolean }>`
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  color: ${(p) => (p.$active ? '#7f55b1' : '#3a1f5a')};
+  color: ${(p) => (p.$active ? p.theme.primaryDark : p.theme.textPrimary)};
   cursor: pointer;
   padding: 0.4rem 0.5rem;
   border-radius: 0.65rem;
   font-size: 0.875rem;
   font-weight: ${(p) => (p.$active ? '600' : '400')};
-  background: ${(p) => (p.$active ? '#e8d8f5' : 'transparent')};
+  background: ${(p) => (p.$active ? p.theme.hoverActive : 'transparent')};
   transition:
     background 0.15s,
     color 0.15s;
@@ -119,8 +119,8 @@ const PlaylistItem = styled.div<{ $active?: boolean }>`
   max-height: 3rem;
 
   &:hover {
-    background: ${(p) => (p.$active ? '#e8d8f5' : '#ede5f8')};
-    color: #7f55b1;
+    background: ${(p) => (p.$active ? p.theme.hoverActive : p.theme.hover)};
+    color: ${({ theme }) => theme.primaryDark};
   }
 `;
 
@@ -136,7 +136,7 @@ const QueueHeader = styled.div`
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   font-weight: 600;
   font-size: 0.9rem;
   cursor: pointer;
@@ -144,7 +144,7 @@ const QueueHeader = styled.div`
   max-height: 2.5rem;
 
   &:hover {
-    color: #7f55b1;
+    color: ${({ theme }) => theme.primaryDark};
   }
 `;
 

--- a/src/Components/Slider/styles.tsx
+++ b/src/Components/Slider/styles.tsx
@@ -1,14 +1,14 @@
 import { styled } from 'styled-components';
 
 const ProgressBarInner = styled.div<{ $height?: number }>`
-  background-color: #f49bab;
+  background-color: ${({ theme }) => theme.accent};
   width: 0; /* Adjust with JavaScript */
   height: ${(props) => props.$height || '15px'};
   border-radius: 10px;
 `;
 
 const CustomProgressBar = styled.div<{ $height?: number }>`
-  background-color: #7f55b1;
+  background-color: ${({ theme }) => theme.primaryDark};
   border-radius: 10px;
   padding: 0px;
   height: ${(props) => props.$height || '15px'};

--- a/src/Components/Song/styles.tsx
+++ b/src/Components/Song/styles.tsx
@@ -33,7 +33,7 @@ const MusicInfo = styled.div`
   padding: 15px 0px;
   display: flex;
   flex-direction: column;
-  color: #f5f2f2;
+  color: ${({ theme }) => theme.textOnPlayer};
 `;
 
 const MusicName = styled.span`

--- a/src/Components/StatusMessage/styles.tsx
+++ b/src/Components/StatusMessage/styles.tsx
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 
 export const StatusMessage = styled.p`
-  color: #7f55b1;
+  color: ${({ theme }) => theme.primaryDark};
   font-size: 1rem;
   text-align: center;
   margin-top: 4rem;

--- a/src/Components/Volume/styles.tsx
+++ b/src/Components/Volume/styles.tsx
@@ -4,35 +4,35 @@ import { styled } from 'styled-components';
 const VolumeXmark = styled(FaVolumeXmark)`
   width: 25px;
   height: 25px;
-  color: #f49bab;
+  color: ${({ theme }) => theme.accent};
   cursor: pointer;
 `;
 
 const VolumeOff = styled(FaVolumeOff)`
   width: 25px;
   height: 25px;
-  color: #f49bab;
+  color: ${({ theme }) => theme.accent};
   cursor: pointer;
 `;
 
 const VolumeLow = styled(FaVolumeLow)`
   width: 25px;
   height: 25px;
-  color: #f49bab;
+  color: ${({ theme }) => theme.accent};
   cursor: pointer;
 `;
 
 const VolumeHigh = styled(FaVolumeHigh)`
   width: 25px;
   height: 25px;
-  color: #f49bab;
+  color: ${({ theme }) => theme.accent};
   cursor: pointer;
 `;
 
 const Heart = styled(FaHeart)<{ $isFavorite: boolean }>`
   width: 25px;
   height: 25px;
-  color: ${(props) => (props.$isFavorite ? '#f49bab' : '#7f55b1')};
+  color: ${(props) => (props.$isFavorite ? props.theme.accent : props.theme.primaryDark)};
   cursor: pointer;
 `;
 

--- a/src/Context/AppContext.tsx
+++ b/src/Context/AppContext.tsx
@@ -1,9 +1,10 @@
-import { createContext } from 'react';
+import React, { createContext } from 'react';
 import { MetadataType, PlaylistType } from '../types';
 
 interface AppContext {
   currentPath?: string;
   currentPlaylist: string[];
+  currentTheme: string;
   isPlaying: boolean;
   isScanning: boolean;
   library: MetadataType[];
@@ -16,11 +17,12 @@ interface AppContext {
   showQueue?: boolean;
   setCurrentPath?: (_path?: string) => void;
   setCurrentPlaylist?: (_playlist: string[]) => void;
+  setCurrentTheme?: (_theme: string) => void;
   setIsScanning?: (_isScanning: boolean) => void;
   setLibrary?: (_library: MetadataType[]) => void;
   setLibraryPaths?: (_paths: string[]) => void;
   scanLibrary?: (_paths: string[]) => Promise<void>;
-  setPlaylists?: (_playlists: PlaylistType[]) => void;
+  setPlaylists?: React.Dispatch<React.SetStateAction<PlaylistType[]>>;
   setIsPlaying?: (_playing: boolean) => void;
   setProgress?: (_progress: number) => void;
   setMetadata?: (_metadata?: MetadataType) => void;
@@ -38,4 +40,5 @@ export const AppContext = createContext<AppContext>({
   libraryPaths: [],
   progress: 0,
   currentPlaylist: [],
+  currentTheme: 'Midnight',
 });

--- a/src/Pages/Albuns/styles.tsx
+++ b/src/Pages/Albuns/styles.tsx
@@ -18,18 +18,18 @@ export const Card = styled.div`
   height: 240px;
   display: flex;
   flex-direction: column;
-  background: #fff;
+  background: ${({ theme }) => theme.cardBackground};
   border-radius: 1rem;
   overflow: hidden;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(90, 58, 122, 0.1);
+  box-shadow: 0 2px 8px ${({ theme }) => theme.cardShadow};
   transition:
     transform 0.15s,
     box-shadow 0.15s;
 
   &:hover {
     transform: translateY(-3px);
-    box-shadow: 0 6px 16px rgba(90, 58, 122, 0.2);
+    box-shadow: 0 6px 16px ${({ theme }) => theme.cardShadowHover};
   }
 `;
 
@@ -51,7 +51,7 @@ export const CardInfo = styled.div`
 `;
 
 export const CardTitle = styled.div`
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   font-weight: 700;
   font-size: 0.9rem;
   white-space: nowrap;
@@ -68,7 +68,7 @@ export const CardBottom = styled.div`
 `;
 
 export const CardArtist = styled.div`
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   font-size: 0.75rem;
   white-space: nowrap;
   overflow: hidden;
@@ -77,7 +77,7 @@ export const CardArtist = styled.div`
 `;
 
 export const CardCount = styled.div`
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   font-size: 0.75rem;
   white-space: nowrap;
   flex-shrink: 0;

--- a/src/Pages/Artists/styles.tsx
+++ b/src/Pages/Artists/styles.tsx
@@ -18,7 +18,7 @@ export const Card = styled.div`
   transition: background 0.15s;
 
   &:hover {
-    background: #f0e8fa;
+    background: ${({ theme }) => theme.surfaceRaised};
   }
 `;
 
@@ -28,7 +28,7 @@ export const Avatar = styled.div`
   aspect-ratio: 1 / 1;
   flex-shrink: 0;
   border-radius: 50%;
-  background: linear-gradient(135deg, #9b7ebd, #f49bab);
+  background: linear-gradient(135deg, ${({ theme }) => theme.primary}, ${({ theme }) => theme.accent});
   color: #fff;
   display: flex;
   align-items: center;
@@ -38,7 +38,7 @@ export const Avatar = styled.div`
 `;
 
 export const ArtistName = styled.div`
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   font-weight: 600;
   font-size: 0.9rem;
   text-align: center;
@@ -49,7 +49,7 @@ export const ArtistName = styled.div`
 `;
 
 export const ArtistMeta = styled.div`
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   font-size: 0.75rem;
   text-align: center;
 `;

--- a/src/Pages/Player/styles.tsx
+++ b/src/Pages/Player/styles.tsx
@@ -3,7 +3,7 @@ import { FaMagnifyingGlass } from 'react-icons/fa6';
 import { AlbumImage, AlbumImagePlaceholder } from '../../Components/Song/styles';
 
 const PlayerContainer = styled.div`
-  background-color: #9b7ebd;
+  background-color: ${({ theme }) => theme.playerBar};
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -24,10 +24,11 @@ const Container = styled.div`
   justify-content: stretch;
   align-items: stretch;
   overflow: hidden;
+  background-color: ${({ theme }) => theme.background};
 `;
 
 const Main = styled.div`
-  background-color: #ffe1e0;
+  background-color: ${({ theme }) => theme.background};
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -58,8 +59,8 @@ const AppHeader = styled.header`
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid #e5d8f5;
-  background: #faf5ff;
+  border-bottom: 1px solid ${({ theme }) => theme.border};
+  background: ${({ theme }) => theme.surface};
   flex-shrink: 0;
   max-height: 3.5rem;
 `;
@@ -76,27 +77,27 @@ const SearchIcon = styled(FaMagnifyingGlass)`
   left: 0.65rem;
   width: 0.75rem;
   height: 0.75rem;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   pointer-events: none;
 `;
 
 const SearchInput = styled.input`
   width: 100%;
   padding: 0.5rem 0.75rem 0.5rem 2rem;
-  border: 1px solid #d4b8f0;
+  border: 1px solid ${({ theme }) => theme.borderLight};
   border-radius: 0.65rem;
-  background: #fff;
+  background: ${({ theme }) => theme.surfaceRaised};
   font-size: 0.85rem;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   outline: none;
   transition: border-color 0.15s;
 
   &::placeholder {
-    color: #b89fd4;
+    color: ${({ theme }) => theme.textMuted};
   }
 
   &:focus {
-    border-color: #9b7ebd;
+    border-color: ${({ theme }) => theme.primary};
   }
 `;
 
@@ -111,14 +112,14 @@ const SettingsButton = styled.button`
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: #7f55b1;
+  color: ${({ theme }) => theme.primaryDark};
   transition:
     background 0.15s,
     color 0.15s;
 
   &:hover {
-    background: #ede5f8;
-    color: #3a1f5a;
+    background: ${({ theme }) => theme.hover};
+    color: ${({ theme }) => theme.textPrimary};
   }
 `;
 

--- a/src/Pages/Playlist/Create.test.tsx
+++ b/src/Pages/Playlist/Create.test.tsx
@@ -29,6 +29,7 @@ const Wrapper = ({
           libraryPaths: [],
           progress: 0,
           currentPlaylist: [],
+          currentTheme: 'Midnight',
           playlists,
           setPlaylists,
         }}

--- a/src/Pages/Playlist/Detail.test.tsx
+++ b/src/Pages/Playlist/Detail.test.tsx
@@ -22,6 +22,7 @@ const defaultContext: AppContextValue = {
   libraryPaths: [],
   progress: 0,
   currentPlaylist: [],
+  currentTheme: 'Midnight',
 };
 
 const renderDetail = (playlists: PlaylistType[], contextOverrides: Partial<AppContextValue> = {}, playlistId = '1') => {

--- a/src/Pages/Playlist/styles.tsx
+++ b/src/Pages/Playlist/styles.tsx
@@ -12,8 +12,8 @@ export const Container = styled.div`
 export const LeftPanel = styled.aside`
   width: 220px;
   flex-shrink: 0;
-  background: #f3e8ff;
-  border-right: 1px solid #d4b8f0;
+  background: ${({ theme }) => theme.surfaceRaised};
+  border-right: 1px solid ${({ theme }) => theme.borderLight};
   display: flex;
   flex-direction: column;
   overflow-y: auto;
@@ -23,8 +23,8 @@ export const LeftPanel = styled.aside`
 export const NewButton = styled.button`
   margin: 0.75rem;
   padding: 0.5rem 0.75rem;
-  background: #9b7ebd;
-  color: #fff;
+  background: ${({ theme }) => theme.primary};
+  color: ${({ theme }) => theme.textOnPrimary};
   border: none;
   border-radius: 2rem;
   font-size: 0.8rem;
@@ -34,7 +34,7 @@ export const NewButton = styled.button`
   max-width: 8rem;
 
   &:hover {
-    background: #7f55b1;
+    background: ${({ theme }) => theme.primaryDark};
   }
 `;
 
@@ -44,13 +44,13 @@ export const PlaylistItem = styled.div<{ $active?: boolean }>`
   gap: 0.5rem;
   padding: 0.6rem 0.75rem;
   cursor: pointer;
-  background: ${(p) => (p.$active ? '#e4d4f7' : 'transparent')};
-  border-left: 3px solid ${(p) => (p.$active ? '#9b7ebd' : 'transparent')};
+  background: ${(p) => (p.$active ? p.theme.active : 'transparent')};
+  border-left: 3px solid ${(p) => (p.$active ? p.theme.primary : 'transparent')};
   transition: background 0.15s;
   max-height: 4rem;
 
   &:hover {
-    background: ${(p) => (p.$active ? '#e4d4f7' : '#ecdff8')};
+    background: ${(p) => (p.$active ? p.theme.active : p.theme.hover)};
   }
 `;
 
@@ -65,7 +65,7 @@ export const PlaylistItemInfo = styled.div`
 export const PlaylistItemName = styled.div`
   font-size: 0.85rem;
   font-weight: 500;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -74,7 +74,7 @@ export const PlaylistItemName = styled.div`
 
 export const PlaylistItemCount = styled.div`
   font-size: 0.7rem;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   max-height: 1.5rem;
 `;
 
@@ -82,7 +82,7 @@ export const DeleteBtn = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  color: #c0a0d8;
+  color: ${({ theme }) => theme.mutedAccent};
   display: flex;
   align-items: center;
   padding: 0.2rem;
@@ -93,7 +93,7 @@ export const DeleteBtn = styled.button`
   max-height: 1.5rem;
 
   &:hover {
-    color: #c0392b;
+    color: ${({ theme }) => theme.error};
   }
 `;
 
@@ -108,7 +108,7 @@ export const RightPanel = styled.main`
 
 export const EmptyState = styled.p`
   margin: auto;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   font-size: 0.9rem;
 `;
 
@@ -123,7 +123,7 @@ export const EditorHeader = styled.div`
 export const NameInput = styled.input`
   font-size: 1.5rem;
   font-weight: 700;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
@@ -133,13 +133,13 @@ export const NameInput = styled.input`
   max-height: 2rem;
 
   &:focus {
-    border-bottom-color: #9b7ebd;
+    border-bottom-color: ${({ theme }) => theme.primary};
   }
 `;
 
 export const SongCount = styled.span`
   font-size: 0.8rem;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   max-height: 2rem;
 `;
 
@@ -163,23 +163,23 @@ export const ColumnTitle = styled.h3`
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #7f55b1;
+  color: ${({ theme }) => theme.primaryDark};
   margin: 0 0 0.25rem;
   max-height: 1.5rem;
 `;
 
 export const SearchInput = styled.input`
   padding: 0.4rem 0.75rem;
-  border: 1px solid #d4b8f0;
+  border: 1px solid ${({ theme }) => theme.borderLight};
   border-radius: 2rem;
   font-size: 0.8rem;
   outline: none;
-  background: #fff;
-  color: #3a1f5a;
+  background: ${({ theme }) => theme.surface};
+  color: ${({ theme }) => theme.textPrimary};
   max-height: 2.5rem;
 
   &:focus {
-    border-color: #9b7ebd;
+    border-color: ${({ theme }) => theme.primary};
   }
 `;
 
@@ -201,7 +201,7 @@ export const SongRow = styled.div`
   max-height: 3rem;
 
   &:hover {
-    background: #ecdff8;
+    background: ${({ theme }) => theme.hover};
   }
 `;
 
@@ -216,7 +216,7 @@ export const SongMeta = styled.div`
 export const SongTitle = styled.div`
   font-size: 0.82rem;
   font-weight: 500;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -224,7 +224,7 @@ export const SongTitle = styled.div`
 
 export const SongArtist = styled.div`
   font-size: 0.72rem;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -246,20 +246,20 @@ export const IconButton = styled.button`
 export const RemoveIcon = styled(FaMinus)`
   max-width: 0.75rem;
   max-height: 0.75rem;
-  color: #c0a0d8;
+  color: ${({ theme }) => theme.mutedAccent};
 
   ${IconButton}:hover & {
-    color: #c0392b;
+    color: ${({ theme }) => theme.error};
   }
 `;
 
 export const AddIcon = styled(FaPlus)`
   max-width: 0.75rem;
   max-height: 0.75rem;
-  color: #c0a0d8;
+  color: ${({ theme }) => theme.mutedAccent};
 
   ${IconButton}:hover & {
-    color: #7f55b1;
+    color: ${({ theme }) => theme.primaryDark};
   }
 `;
 
@@ -270,6 +270,6 @@ export const TrashIcon = styled(FaTrash)`
 
 export const EmptyColumn = styled.p`
   font-size: 0.8rem;
-  color: #c0a0d8;
+  color: ${({ theme }) => theme.mutedAccent};
   margin: 0;
 `;

--- a/src/Pages/Search/Search.test.tsx
+++ b/src/Pages/Search/Search.test.tsx
@@ -15,6 +15,7 @@ const defaultContext: AppContextValue = {
   libraryPaths: [],
   progress: 0,
   currentPlaylist: [],
+  currentTheme: 'Midnight',
 };
 
 const library: MetadataType[] = [

--- a/src/Pages/Search/styles.tsx
+++ b/src/Pages/Search/styles.tsx
@@ -21,7 +21,7 @@ export const SectionTitle = styled.h2`
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   margin: 0 0 0.5rem;
   max-height: 1.5rem;
 `;
@@ -37,7 +37,7 @@ export const SongRow = styled.div`
   max-height: 3rem;
 
   &:hover {
-    background: #f3e8ff;
+    background: ${({ theme }) => theme.hover};
   }
 `;
 
@@ -49,7 +49,7 @@ export const SongInfo = styled.div`
 
 export const SongTitle = styled.span`
   font-size: 0.9rem;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -59,7 +59,7 @@ export const SongTitle = styled.span`
 
 export const SongArtist = styled.span`
   font-size: 0.8rem;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   display: flex;
   align-items: center;
 `;
@@ -76,7 +76,7 @@ export const ArtistRow = styled.div`
   max-width: 8rem;
 
   &:hover {
-    background: #f3e8ff;
+    background: ${({ theme }) => theme.hover};
   }
 `;
 
@@ -84,8 +84,8 @@ export const ArtistAvatar = styled.div`
   width: 3.5rem;
   height: 3.5rem;
   border-radius: 50%;
-  background: #d4b8f0;
-  color: #3a1f5a;
+  background: ${({ theme }) => theme.borderLight};
+  color: ${({ theme }) => theme.textPrimary};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -96,7 +96,7 @@ export const ArtistAvatar = styled.div`
 
 export const ArtistName = styled.span`
   font-size: 0.9rem;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   max-height: 1.5rem;
   text-align: center;
 `;
@@ -112,7 +112,7 @@ export const AlbumRow = styled.div`
   max-height: 3rem;
 
   &:hover {
-    background: #f3e8ff;
+    background: ${({ theme }) => theme.hover};
   }
 `;
 
@@ -132,7 +132,7 @@ export const AlbumInfo = styled.div`
 
 export const AlbumTitle = styled.span`
   font-size: 0.9rem;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -140,11 +140,11 @@ export const AlbumTitle = styled.span`
 
 export const AlbumArtist = styled.span`
   font-size: 0.8rem;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
 `;
 
 export const NoResults = styled.p`
   font-size: 0.8rem;
-  color: #b89fd4;
+  color: ${({ theme }) => theme.textMuted};
   margin: 0;
 `;

--- a/src/Pages/Settings/Settings.test.tsx
+++ b/src/Pages/Settings/Settings.test.tsx
@@ -21,6 +21,25 @@ describe('Settings', () => {
     expect(getByText('Music Library Paths')).toBeInTheDocument();
   });
 
+  describe('theme selector', () => {
+    it('renders the Appearance section', () => {
+      const { getByText } = renderWithContext(<Settings />);
+      expect(getByText('Appearance')).toBeInTheDocument();
+    });
+
+    it('shows the current theme as the selected option', () => {
+      const { getByRole } = renderWithContext(<Settings />, { currentTheme: 'Pastel Colors' });
+      expect(getByRole('combobox')).toHaveValue('Pastel Colors');
+    });
+
+    it('calls setCurrentTheme when a different theme is selected', () => {
+      const setCurrentTheme = vi.fn();
+      const { getByRole } = renderWithContext(<Settings />, { currentTheme: 'Midnight', setCurrentTheme });
+      fireEvent.change(getByRole('combobox'), { target: { value: 'Pastel Colors' } });
+      expect(setCurrentTheme).toHaveBeenCalledWith('Pastel Colors');
+    });
+  });
+
   it('shows empty note when no paths are configured', () => {
     const { getByText } = renderWithContext(<Settings />, { libraryPaths: [] });
     expect(getByText(/default system music directory/i)).toBeInTheDocument();

--- a/src/Pages/Settings/Settings.tsx
+++ b/src/Pages/Settings/Settings.tsx
@@ -2,6 +2,7 @@ import { useContext, useRef, useState } from 'react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
 import { AppContext } from '../../Context/AppContext';
+import { themes } from '../../theme';
 import {
   AddButton,
   ButtonRow,
@@ -18,11 +19,15 @@ import {
   SectionTitle,
   SettingsContainer,
   SuccessBadge,
+  ThemeLabel,
+  ThemeRow,
+  ThemeSelect,
   TrashIcon,
 } from './styles';
 
 const Settings = () => {
-  const { libraryPaths, setLibraryPaths, scanLibrary, isScanning } = useContext(AppContext);
+  const { libraryPaths, setLibraryPaths, scanLibrary, isScanning, currentTheme, setCurrentTheme } =
+    useContext(AppContext);
   const [scanSuccess, setScanSuccess] = useState(false);
   const successTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -58,6 +63,20 @@ const Settings = () => {
 
   return (
     <SettingsContainer>
+      <Section>
+        <SectionTitle>Appearance</SectionTitle>
+        <ThemeRow>
+          <ThemeLabel htmlFor="theme-select">Theme</ThemeLabel>
+          <ThemeSelect id="theme-select" value={currentTheme} onChange={(e) => setCurrentTheme?.(e.target.value)}>
+            {Object.keys(themes).map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </ThemeSelect>
+        </ThemeRow>
+      </Section>
+
       <Section>
         <SectionTitle>Music Library Paths</SectionTitle>
 

--- a/src/Pages/Settings/styles.tsx
+++ b/src/Pages/Settings/styles.tsx
@@ -19,10 +19,10 @@ export const Section = styled.section`
 export const SectionTitle = styled.h2`
   font-size: 1rem;
   font-weight: 600;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   margin: 0;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid #d4b8f0;
+  border-bottom: 1px solid ${({ theme }) => theme.borderLight};
   max-height: 1.5rem;
 `;
 
@@ -39,8 +39,8 @@ export const PathItem = styled.li`
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  background: #f3e8ff;
-  border: 1px solid #d4b8f0;
+  background: ${({ theme }) => theme.surfaceRaised};
+  border: 1px solid ${({ theme }) => theme.borderLight};
   border-radius: 0.5rem;
   padding: 0.6rem 0.9rem;
   max-height: 2.5rem;
@@ -49,7 +49,7 @@ export const PathItem = styled.li`
 export const PathText = styled.span`
   flex: 1;
   font-size: 0.85rem;
-  color: #3a1f5a;
+  color: ${({ theme }) => theme.textPrimary};
   word-break: break-all;
 `;
 
@@ -57,7 +57,7 @@ export const RemoveButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   display: flex;
   align-items: center;
   padding: 0.2rem;
@@ -67,7 +67,7 @@ export const RemoveButton = styled.button`
   max-width: 1.5rem;
 
   &:hover {
-    color: #c0392b;
+    color: ${({ theme }) => theme.error};
   }
 `;
 
@@ -75,8 +75,8 @@ export const AddButton = styled.button`
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  background: #9b7ebd;
-  color: #fff;
+  background: ${({ theme }) => theme.primary};
+  color: ${({ theme }) => theme.textOnPrimary};
   border: none;
   border-radius: 2rem;
   padding: 0.5rem 1.2rem;
@@ -87,7 +87,7 @@ export const AddButton = styled.button`
   max-height: 2.5rem;
 
   &:hover {
-    background: #7f55b1;
+    background: ${({ theme }) => theme.primaryDark};
   }
 
   &:disabled {
@@ -98,7 +98,7 @@ export const AddButton = styled.button`
 
 export const EmptyNote = styled.p`
   font-size: 0.85rem;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
   margin: 0;
 `;
 
@@ -132,8 +132,8 @@ export const RescanButton = styled.button`
   align-items: center;
   gap: 0.5rem;
   background: none;
-  color: #9b7ebd;
-  border: 1.5px solid #9b7ebd;
+  color: ${({ theme }) => theme.primary};
+  border: 1.5px solid ${({ theme }) => theme.primary};
   border-radius: 2rem;
   padding: 0.5rem 1.2rem;
   font-size: 0.875rem;
@@ -145,7 +145,7 @@ export const RescanButton = styled.button`
   max-height: 2.5rem;
 
   &:hover {
-    background: #f3e8ff;
+    background: ${({ theme }) => theme.surfaceRaised};
   }
 
   &:disabled {
@@ -165,10 +165,44 @@ export const RescanIcon = styled(FaArrowsRotate)<{ $spinning?: boolean }>`
 
 export const ScanningBadge = styled.span`
   font-size: 0.8rem;
-  color: #9b7ebd;
+  color: ${({ theme }) => theme.primary};
 `;
 
 export const SuccessBadge = styled.span`
   font-size: 0.8rem;
-  color: #2e7d32;
+  color: ${({ theme }) => theme.success};
+`;
+
+export const ThemeRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  max-height: 2.5rem;
+`;
+
+export const ThemeLabel = styled.label`
+  font-size: 0.9rem;
+  color: ${({ theme }) => theme.textPrimary};
+  min-width: 4rem;
+`;
+
+export const ThemeSelect = styled.select`
+  -webkit-appearance: none;
+  appearance: none;
+  padding: 0.4rem 2rem 0.4rem 0.75rem;
+  border: 1px solid ${({ theme }) => theme.borderLight};
+  border-radius: 0.5rem;
+  background-color: ${({ theme }) => theme.surfaceRaised};
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%237A8194' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.65rem center;
+  color: ${({ theme }) => theme.textPrimary};
+  font-size: 0.875rem;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.15s;
+
+  &:focus {
+    border-color: ${({ theme }) => theme.primary};
+  }
 `;

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -1,0 +1,7 @@
+import 'styled-components';
+import { AppTheme } from './theme';
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  export interface DefaultTheme extends AppTheme {}
+}

--- a/src/test/helpers.tsx
+++ b/src/test/helpers.tsx
@@ -13,6 +13,7 @@ const defaultContext: AppContextValue = {
   libraryPaths: [],
   progress: 0,
   currentPlaylist: [],
+  currentTheme: 'Midnight',
 };
 
 export const renderWithContext = (

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,123 @@
+export interface AppTheme {
+  name: string;
+
+  // Brand
+  primary: string;
+  primaryDark: string;
+  primaryDeep: string;
+
+  // Backgrounds
+  background: string;
+  surface: string;
+  surfaceAlt: string;
+  surfaceRaised: string;
+
+  // Text
+  textPrimary: string;
+  textSecondary: string;
+  textMuted: string;
+  textOnPrimary: string;
+  textOnPlayer: string;
+
+  // Interactive states
+  hover: string;
+  hoverActive: string;
+  active: string;
+
+  // Borders
+  border: string;
+  borderLight: string;
+
+  // Accent (controls, icons, active track highlights)
+  accent: string;
+  accentBg: string;
+  accentBgHover: string;
+  accentHover: string;
+  mutedAccent: string;
+
+  // Cards
+  cardBackground: string;
+  cardShadow: string;
+  cardShadowHover: string;
+
+  // Functional
+  success: string;
+  warning: string;
+  error: string;
+
+  // Player bar
+  playerBar: string;
+}
+
+export const pastelTheme: AppTheme = {
+  name: 'Pastel Colors',
+  primary: '#9b7ebd',
+  primaryDark: '#7f55b1',
+  primaryDeep: '#5a3a7a',
+  background: '#ffe1e0',
+  surface: '#faf5ff',
+  surfaceAlt: '#f7f4fc',
+  surfaceRaised: '#f3e8ff',
+  textPrimary: '#3a1f5a',
+  textSecondary: '#6b4c8a',
+  textMuted: '#b89fd4',
+  textOnPrimary: '#ffffff',
+  textOnPlayer: '#f5f2f2',
+  hover: '#ede5f8',
+  hoverActive: '#e8d8f5',
+  active: '#e4d4f7',
+  border: '#e5d8f5',
+  borderLight: '#d4b8f0',
+  accent: '#f49bab',
+  accentBg: '#f49bab33',
+  accentBgHover: '#f49bab55',
+  accentHover: '#f7cdd4',
+  mutedAccent: '#c0a0d8',
+  cardBackground: '#ffffff',
+  cardShadow: 'rgba(90, 58, 122, 0.1)',
+  cardShadowHover: 'rgba(90, 58, 122, 0.2)',
+  success: '#2e7d32',
+  warning: '#F2C94C',
+  error: '#c0392b',
+  playerBar: '#9b7ebd',
+};
+
+export const midnightTheme: AppTheme = {
+  name: 'Midnight',
+  primary: '#3F3BD1',
+  primaryDark: '#2F2CC3',
+  primaryDeep: '#2320A0',
+  background: '#0F1115',
+  surface: '#1A1D24',
+  surfaceAlt: '#232733',
+  surfaceRaised: '#232733',
+  textPrimary: '#FFFFFF',
+  textSecondary: '#B8BCC8',
+  textMuted: '#7A8194',
+  textOnPrimary: '#FFFFFF',
+  textOnPlayer: '#FFFFFF',
+  hover: '#1F2330',
+  hoverActive: '#252836',
+  active: '#2A2D3E',
+  border: '#2A2D3A',
+  borderLight: '#323645',
+  accent: '#AEB3FF',
+  accentBg: 'rgba(174, 179, 255, 0.12)',
+  accentBgHover: 'rgba(174, 179, 255, 0.22)',
+  accentHover: 'rgba(174, 179, 255, 0.07)',
+  mutedAccent: '#4A4E6E',
+  cardBackground: '#1A1D24',
+  cardShadow: 'rgba(0, 0, 0, 0.25)',
+  cardShadowHover: 'rgba(0, 0, 0, 0.45)',
+  success: '#4CAF50',
+  warning: '#F2C94C',
+  error: '#EB5757',
+  playerBar: '#1A1D24',
+};
+
+export const themes: Record<string, AppTheme> = {
+  Midnight: midnightTheme,
+  'Pastel Colors': pastelTheme,
+};
+
+export const defaultTheme = midnightTheme;


### PR DESCRIPTION
## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other

## Description

This PR implements ThemeProvider to the whole app and creates a way of creating new themes and changing it on the fly in the settings page

Closes #3 

## Changes

- Implements styledComponents ThemeProvider
- Refactors ui removing hardcoded colors in favour of theme variables

## Testing

Describe how you tested this. Check all that apply:

- [x] Added or updated unit tests
- [x] Manually tested the affected feature
- [x] Verified no regressions in related areas

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` passes
- [x] PR targets `main` (not `release`)

## Screenshots

If this changes the UI, include a before/after screenshot.
