### PR TITLE
refactor(metadata): drop AudioMetadata::new in favor of struct-init

### DIFF
--- a/src-tauri/src/db/commands.rs
+++ b/src-tauri/src/db/commands.rs
@@ -211,16 +211,19 @@ pub(crate) fn get_cached_tracks(conn: &Connection) -> Result<Vec<AudioMetadata>,
             let track: Option<i64> = row.get(5)?;
             let duration_seconds: Option<i64> = row.get(6)?;
             let duration_formatted: Option<String> = row.get(7)?;
-            Ok(AudioMetadata::new(
+            Ok(AudioMetadata {
                 title,
                 artist,
                 album,
                 year,
-                track.map(|n| n as u32),
-                AudioDuration::new(duration_seconds.map(|n| n as u64), duration_formatted),
-                Some(path),
-                None, // image is lazy-loaded on demand
-            ))
+                track: track.map(|n| n as u32),
+                duration: AudioDuration::new(
+                    duration_seconds.map(|n| n as u64),
+                    duration_formatted,
+                ),
+                path: Some(path),
+                image: None, // image is lazy-loaded on demand
+            })
         })
         .map_err(|e| e.to_string())?
         .collect::<Result<_, _>>()
@@ -674,29 +677,29 @@ mod tests {
     // ── tracks ────────────────────────────────────────────────────────────────
 
     fn make_meta(path: &str, title: &str, mtime_marker_artist: &str) -> AudioMetadata {
-        AudioMetadata::new(
-            Some(title.into()),
-            Some(mtime_marker_artist.into()),
-            Some("Album".into()),
-            Some("2024".into()),
-            None,
-            AudioDuration::new(Some(180), Some("03:00".into())),
-            Some(path.into()),
-            None,
-        )
+        AudioMetadata {
+            title: Some(title.into()),
+            artist: Some(mtime_marker_artist.into()),
+            album: Some("Album".into()),
+            year: Some("2024".into()),
+            track: None,
+            duration: AudioDuration::new(Some(180), Some("03:00".into())),
+            path: Some(path.into()),
+            image: None,
+        }
     }
 
     fn make_meta_with_track(path: &str, title: &str, track: Option<u32>) -> AudioMetadata {
-        AudioMetadata::new(
-            Some(title.into()),
-            Some("Artist".into()),
-            Some("Album".into()),
-            Some("2024".into()),
+        AudioMetadata {
+            title: Some(title.into()),
+            artist: Some("Artist".into()),
+            album: Some("Album".into()),
+            year: Some("2024".into()),
             track,
-            AudioDuration::new(Some(180), Some("03:00".into())),
-            Some(path.into()),
-            None,
-        )
+            duration: AudioDuration::new(Some(180), Some("03:00".into())),
+            path: Some(path.into()),
+            image: None,
+        }
     }
 
     #[test]

--- a/src-tauri/src/metadata/commands.rs
+++ b/src-tauri/src/metadata/commands.rs
@@ -68,14 +68,14 @@ pub fn get_metadata(path: &str) -> Result<AudioMetadata, String> {
         "Title: {:?}, Artist: {:?}, Album: {:?}, Year: {:?}, Track: {:?}, Duration: {:?}",
         title, artist, album, year, track, duration
     );
-    Ok(AudioMetadata::new(
+    Ok(AudioMetadata {
         title,
         artist,
         album,
         year,
         track,
         duration,
-        Some(path.to_string()),
+        path: Some(path.to_string()),
         image,
-    ))
+    })
 }

--- a/src-tauri/src/metadata/types.rs
+++ b/src-tauri/src/metadata/types.rs
@@ -27,30 +27,6 @@ pub struct AudioMetadata {
     pub image: Option<String>,
 }
 
-impl AudioMetadata {
-    pub fn new(
-        title: Option<String>,
-        artist: Option<String>,
-        album: Option<String>,
-        year: Option<String>,
-        track: Option<u32>,
-        duration: AudioDuration,
-        path: Option<String>,
-        image: Option<String>,
-    ) -> Self {
-        AudioMetadata {
-            title,
-            artist,
-            album,
-            year,
-            track,
-            duration,
-            path,
-            image,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,16 +46,16 @@ mod tests {
     #[test]
     fn audio_metadata_new_and_serialize() {
         let dur = AudioDuration::new(Some(100), Some("01:40".to_string()));
-        let meta = AudioMetadata::new(
-            Some("Title".into()),
-            Some("Artist".into()),
-            Some("Album".into()),
-            Some("2020".into()),
-            Some(3),
-            dur,
-            Some("path.mp3".into()),
-            Some("imgdata".into()),
-        );
+        let meta = AudioMetadata {
+            title: Some("Title".into()),
+            artist: Some("Artist".into()),
+            album: Some("Album".into()),
+            year: Some("2020".into()),
+            track: Some(3),
+            duration: dur,
+            path: Some("path.mp3".into()),
+            image: Some("imgdata".into()),
+        };
 
         let s = serde_json::to_value(&meta).expect("serialize");
         assert_eq!(s["title"], json!("Title"));


### PR DESCRIPTION
## Type

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other

## Description

A brief summary of what this PR does and why.

Closes # (issue)

## Changes

- 
- 
- 

## Testing

Describe how you tested this. Check all that apply:

- [ ] Added or updated unit tests
- [ ] Manually tested the affected feature
- [ ] Verified no regressions in related areas

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` passes
- [x] PR targets `main` (not `release`)

## Screenshots

If this changes the UI, include a before/after screenshot.
